### PR TITLE
Update coins.c for Zcash mainnet

### DIFF
--- a/firmware/coins.c
+++ b/firmware/coins.c
@@ -28,6 +28,7 @@ const CoinType coins[COINS_COUNT] = {
 	{true, "Litecoin", true, "LTC",  true,  48, true,    1000000, true,   5, false, 0, false, 0, true, "\x19" "Litecoin Signed Message:\n"},
 	{true, "Dogecoin", true, "DOGE", true,  30, true, 1000000000, true,  22, false, 0, false, 0, true, "\x19" "Dogecoin Signed Message:\n"},
 	{true, "Dash",     true, "DASH", true,  76, true,     100000, true,  16, false, 0, false, 0, true, "\x19" "DarkCoin Signed Message:\n"},
+	{true, "Zcash",    true, "ZEC",  true,  65, true,    1000000, true,   5, false, 0, false, 0, true, "\x19" "Zcash Signed Message:\n"},
 };
 
 const CoinType *coinByShortcut(const char *shortcut)


### PR DESCRIPTION
The address prefix for Mainnet is 'T' (uppercase) so the byte value is 65 (decimal).

Not sure about the leading byte for the last parameter, the signed message, but since only bitcoin uses 0x18 and all others use 0x19, this patch also uses 0x19.
